### PR TITLE
Update serve.js

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -21,7 +21,7 @@ module.exports = (directory) => {
     }
     let port = directory.port || defaultPort;
     let path = dir + (directory.path || '');
-    let entry = directory.entry || descriptor? descriptor.main : null || 'index.html';
+    let entry = directory.entry || (descriptor? descriptor.main : null) || 'index.html';
     let keepAliveInter = {};
 
     browserSync.init({


### PR DESCRIPTION
fix/ wrong entry evaluation - add parentheses to scope  logical turnery operation
current: directory.entry || descriptor ? descriptor.main : null
actually evaluates to (directory.entry || descriptor) ? descriptor.main : null